### PR TITLE
✨ feature(provider): Added Provider and AuthProvider + implementation…

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,64 @@
+use std::fmt::Debug;
+
+use rocket::Request; 
+
 pub mod solana;
 
+/// Trait for implementing wallet-based authentication providers.
+///
+/// This trait defines the behavior needed to extract and verify 
+/// identity information from incoming requests, typically for 
+/// blockchain-based login flows (e.g., Solana, Ethereum).
+///
+/// A type implementing `AuthProvider` can be used as a request guard
+/// via [`Provider<T>`], enabling generic request extraction and verification.
+///
+/// # Example
+/// See [`SolanaAuth`] for a concrete implementation.
 pub trait AuthProvider {
+    /// Error type returned during header parsing or signature verification.
+    type Error: Debug + Send + Sync;
+
+    /// Verifies the authenticity of the provided credentials and message signature.
+    ///
+    /// Returns `Ok(())` on success, or an error if the signature is invalid.
+    fn verify(&self) -> Result<(), Self::Error>;
+
+    /// Attempts to construct an authentication struct from request headers.
+    ///
+    /// Expected headers may vary per implementation, e.g.:
+    /// - `X-signature`
+    /// - `X-public-key`
+    /// - `X-message`
+    fn from_headers<'a>(req: &Request<'a>) -> Result<Self, Self::Error> where Self: Sized + Send + Sync;
+
+    /// Returns a stable identifier (typically a public key or wallet address)
+    /// used as the JWT subject (`sub`) or application-level identity.
     fn subject(&self) -> String;
+}
+
+/// A generic request guard wrapper for implementing blockchain-based authentication.
+///
+/// `Provider<T>` is used internally to wrap any type that implements [`AuthProvider`],
+/// providing a reusable `FromRequest` implementation for Rocket (or other frameworks).
+///
+/// This allows different providers (e.g. [`SolanaAuth`]) to plug into the same request
+/// handling mechanism without duplicating integration logic.
+///
+/// Most users will not interact with this type directly — instead, they should use
+/// the specific provider types exposed by the crate.
+///
+/// # Framework Integration
+/// Each provider (e.g. `SolanaAuth`) delegates its request guard implementation
+/// to `Provider<T>` behind the scenes.
+///
+/// # Example
+/// ```rust
+/// #[rocket::get("/protected")]
+/// fn protected(auth: SolanaAuth) {
+///     // Internally uses Provider<SolanaAuth> for verification
+/// }
+/// ```
+pub struct Provider<T: AuthProvider + Send + Sync> {
+    auth: T
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -54,10 +54,15 @@ pub trait AuthProvider {
 ///
 /// # Example
 /// ```rust
+/// use solana_web_token::providers::solana::SolanaAuth;
+/// 
 /// #[rocket::get("/protected")]
-/// fn protected(auth: SolanaAuth) {
-///     // Internally uses Provider<SolanaAuth> for verification
+/// fn protected_route(auth: SolanaAuth) -> String {
+///     format!("Authenticated: {}", auth.credentials)
 /// }
+/// 
+/// #[rocket::main]
+/// async fn main() {}
 /// ```
 pub struct Provider<T: AuthProvider + Send + Sync> {
     auth: T

--- a/src/providers/solana.rs
+++ b/src/providers/solana.rs
@@ -34,10 +34,15 @@ use super::*;
 ///
 /// Use `SolanaAuth` directly in your route:
 /// ```rust
-/// #[get("/protected")]
+/// use solana_web_token::providers::solana::SolanaAuth;
+/// 
+/// #[rocket::get("/protected")]
 /// fn protected_route(auth: SolanaAuth) -> String {
 ///     format!("Authenticated: {}", auth.credentials)
 /// }
+/// 
+/// #[rocket::main]
+/// async fn main() {}
 /// ```
 pub struct SolanaAuth {
     pub credentials: Pubkey,


### PR DESCRIPTION
# Changes:

## Summary
See [Feature: Add Generic Provider<T: AuthProvider> Wrapper #2](https://github.com/joewxlker/solana_web_token/issues/2)

## Additions
- ```struct Provider<T: AuthProvider>```:
    - Wraps values implementing ```AuthProvider```
    - Provides access to inner value for ```FromRequest``` trait impl
- ```trait AuthProvider```:
    - Extracts credentials from requests
    - Validates credentials
    - Exposes ```subject``` value

## Affected
- ```SolanaAuth```
    - Core logic and handling has been updated to use latest AuthProvider/Provider changes
    - Unit tests updated to use latest AuthProvider/Provider changes

Closes: #2