### PR TITLE
🚑 hotfix(rocket): Restore feature flag + decouple AuthProvider from Rocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,6 @@ once_cell = "1.19.0"
 rocket = { version = "0.5.1", features = ["json", "secrets"] }
 
 [[example]]
+required-features = ["rocket"]
 name = "wallet_auth"
 path = "examples/rocket_wallet_auth.rs"

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,10 +1,17 @@
 use base64::{prelude::BASE64_STANDARD, Engine};
 use jsonwebtoken::{DecodingKey, EncodingKey};
-use rocket::{http::Status, request::{FromRequest, Outcome}};
 use serde::{de::DeserializeOwned, Serialize};
-use rocket::Request;
 
-use crate::{error::AuthTokenFromRequestError, providers::AuthProvider, token::AuthToken};
+#[cfg(feature="rocket")]
+use rocket::{
+    http::Status, Request, 
+    request::{FromRequest, Outcome}
+};
+
+#[cfg(feature="rocket")]
+use crate::error::AuthTokenFromRequestError;
+
+use crate::{providers::AuthProvider, token::AuthToken};
 
 
 /// A manager for signing and verifying JWTs using ES256 (ECDSA P-256).

--- a/src/providers/solana.rs
+++ b/src/providers/solana.rs
@@ -65,17 +65,17 @@ impl AuthProvider for SolanaAuth {
     }
 
     fn from_headers(headers: Headers) -> Result<Self, Self::Error> {
-        let signature = match headers.0.get("X-signature") {
+        let signature = match headers.0.get("x-signature") {
             Some(signature) => Signature::from_str(signature)?,
             None => return Err(SolanaAuthError::MissingCredentials)
         };
 
-        let credentials = match headers.0.get("X-public-key") {
+        let credentials = match headers.0.get("x-public-key") {
             Some(public_key) => Pubkey::from_str(public_key)?,
             None => return Err(SolanaAuthError::MissingCredentials)
         };
 
-        let message = match headers.0.get("X-message") {
+        let message = match headers.0.get("x-message") {
             Some(message) => message.to_string(),
             None => return Err(SolanaAuthError::MissingCredentials)
         };


### PR DESCRIPTION
## 🛠 Summary

This hotfix addresses missing Rocket-related feature flags and resolves dependency coupling between `AuthProvider` and `rocket::Request`.

The `AuthProvider` trait previously accepted a `Request` directly, which prevented support for other frameworks and introduced unnecessary dependency requirements.

This PR introduces the `Headers` abstraction to solve this cleanly.

## ➕ Additions

- Added `Headers` struct:
  - Wraps a `HashMap<String, String>`
  - Provides generic header access for use in `AuthProvider::from_headers`
  - Frameworks can implement `From<T>` to map their request type into `Headers`
- Added `#[cfg(feature = "rocket")]` to Rocket-specific implementations
- Updated feature flags in `Cargo.toml` to properly gate Rocket support

## ✅ Outcome

- `AuthProvider` is now framework-agnostic
- Rocket support is restored, but optional
- Unblocks multi-framework integration going forward